### PR TITLE
Add bulk-permissions API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/fatih/structs v1.1.0
+	github.com/go-test/deep v1.0.8 // indirect
 	github.com/golang-jwt/jwt/v4 v4.4.1
 	github.com/google/go-cmp v0.5.7
 	github.com/google/go-querystring v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
+github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
+github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/golang-jwt/jwt/v4 v4.4.1 h1:pC5DB52sCeK48Wlb9oPcdhnjkz1TKt1D/P7WKJ0kUcQ=
 github.com/golang-jwt/jwt/v4 v4.4.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/jira.go
+++ b/jira.go
@@ -41,6 +41,7 @@ type Client struct {
 	Authentication   *AuthenticationService
 	Issue            *IssueService
 	Project          *ProjectService
+	Permissions      *PermissionsService
 	Board            *BoardService
 	Sprint           *SprintService
 	User             *UserService
@@ -91,6 +92,7 @@ func NewClient(httpClient httpClient, baseURL string) (*Client, error) {
 	c.Authentication = &AuthenticationService{client: c}
 	c.Issue = &IssueService{client: c}
 	c.Project = &ProjectService{client: c}
+	c.Permissions = &PermissionsService{client: c}
 	c.Board = &BoardService{client: c}
 	c.Sprint = &SprintService{client: c}
 	c.User = &UserService{client: c}

--- a/mocks/check_permissions.json
+++ b/mocks/check_permissions.json
@@ -1,0 +1,18 @@
+{
+  "projectPermissions": [
+    {
+      "permission": "EDIT_ISSUES",
+      "issues": [
+        10010,
+        10013,
+        10014
+      ],
+      "projects": [
+        10001
+      ]
+    }
+  ],
+  "globalPermissions": [
+    "ADMINISTER"
+  ]
+}

--- a/mocks/check_permissions_request.json
+++ b/mocks/check_permissions_request.json
@@ -1,0 +1,22 @@
+{
+  "globalPermissions": [
+    "ADMINISTER"
+  ],
+  "projectPermissions": [
+    {
+      "projects": [
+        10001
+      ],
+      "permissions": [
+        "EDIT_ISSUES"
+      ],
+      "issues": [
+        10010,
+        10011,
+        10012,
+        10013,
+        10014
+      ]
+    }
+  ]
+}

--- a/permissions.go
+++ b/permissions.go
@@ -11,6 +11,28 @@ type PermissionsService struct {
 	client *Client
 }
 
+type BulkProjectPermissions struct {
+	Permission   string `json:"permission"`
+	ProjectIDs   []int  `json:"projects"`
+	IssueTypeIDs []int  `json:"issues"`
+}
+
+type BulkPermissions struct {
+	ProjectPermissions []*BulkProjectPermissions `json:"projectPermissions"`
+	GlobalPermissions  []string                  `json:"globalPermissions"`
+}
+type requestProjectPermission struct {
+	Permissions  []string `json:"permissions"`
+	ProjectIDs   []int    `json:"projects"`
+	IssueTypeIDs []int    `json:"issues"`
+}
+
+type requestBulkPermissions struct {
+	AccountID          string                     `json:"accountId,omitempty"`
+	GlobalPermissions  []string                   `json:"globalPermissions,omitempty"`
+	ProjectPermissions []requestProjectPermission `json:"projectPermissions,omitempty"`
+}
+
 // GetBulkPermissionsWithContext takes a list of projects with issue type IDs and
 // returns permissions given user (or currently-authed user if that is not set)
 // is granted on those projects and issue types. globalPermissions can also be

--- a/permissions.go
+++ b/permissions.go
@@ -1,0 +1,47 @@
+package jira
+
+import (
+	"context"
+)
+
+// PermissionsService handles projects for the Jira instance / API.
+//
+// Jira API docs: https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-permissions/
+type PermissionsService struct {
+	client *Client
+}
+
+// GetBulkPermissionsWithContext takes a list of projects with issue type IDs and
+// returns permissions given user (or currently-authed user if that is not set)
+// is granted on those projects and issue types. globalPermissions can also be
+// passed, which will check non-project-specific permissions too.
+//
+// https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-permissions/#api-rest-api-2-permissions-check-post
+func (s *PermissionsService) GetBulkPermissionsWithContext(ctx context.Context, accountID string, globalPermissions, permissions []string, projectIDs []int, issueTypeIDs []int) (*BulkPermissions, *Response, error) {
+	reqBody := requestBulkPermissions{
+		AccountID:         accountID,
+		GlobalPermissions: globalPermissions,
+		ProjectPermissions: []requestProjectPermission{{
+			Permissions:  permissions,
+			ProjectIDs:   projectIDs,
+			IssueTypeIDs: issueTypeIDs,
+		}},
+	}
+
+	req, err := s.client.NewRequestWithContext(ctx, "POST", "/rest/api/2/permissions/check", reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	bs := new(BulkPermissions)
+	resp, err := s.client.Do(req, bs)
+	if err != nil {
+		return nil, resp, NewJiraError(resp, err)
+	}
+
+	return bs, resp, nil
+}
+
+func (s *PermissionsService) GetBulkPermissions(accountID string, globalPermissions, permissions []string, projectIDs, issueTypeIDs []int) (*BulkPermissions, *Response, error) {
+	return s.GetBulkPermissionsWithContext(context.Background(), accountID, globalPermissions, permissions, projectIDs, issueTypeIDs)
+}

--- a/permissions_test.go
+++ b/permissions_test.go
@@ -1,0 +1,48 @@
+package jira
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+func TestPermissionsService_GetBulk(t *testing.T) {
+	setup()
+	defer teardown()
+	testAPIEndpoint := "/rest/api/2/permissions/check"
+
+	req, err := ioutil.ReadFile("./mocks/check_permissions_request.json")
+	if err != nil {
+		t.Error(err.Error())
+	}
+	var reqBody map[string]interface{}
+	if err := json.Unmarshal(req, &reqBody); err != nil {
+		t.Error(err.Error())
+	}
+
+	resp, err := ioutil.ReadFile("./mocks/check_permissions.json")
+	if err != nil {
+		t.Error(err.Error())
+	}
+	testMux.HandleFunc(testAPIEndpoint, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testRequestURL(t, r, testAPIEndpoint)
+		testRequestBody(t, r, reqBody)
+		fmt.Fprint(w, string(resp))
+	})
+
+	bulkPerms, _, err := testClient.Permissions.GetBulkPermissions(
+		"",
+		[]string{"ADMINISTER"},
+		[]string{"EDIT_ISSUES"},
+		[]int{10001},
+		[]int{10010, 10011, 10012, 10013, 10014})
+	if bulkPerms == nil {
+		t.Error("Expected bulkPerms list. BulkPerms list is nil")
+	}
+	if err != nil {
+		t.Errorf("Error given: %s", err)
+	}
+}

--- a/project.go
+++ b/project.go
@@ -180,25 +180,3 @@ func (s *ProjectService) GetPermissionSchemeWithContext(ctx context.Context, pro
 func (s *ProjectService) GetPermissionScheme(projectID string) (*PermissionScheme, *Response, error) {
 	return s.GetPermissionSchemeWithContext(context.Background(), projectID)
 }
-
-type BulkProjectPermissions struct {
-	Permission   string `json:"permission"`
-	ProjectIDs   []int  `json:"projects"`
-	IssueTypeIDs []int  `json:"issues"`
-}
-
-type BulkPermissions struct {
-	ProjectPermissions []*BulkProjectPermissions `json:"projectPermissions"`
-	GlobalPermissions  []string                  `json:"globalPermissions"`
-}
-type requestProjectPermission struct {
-	Permissions  []string `json:"permissions"`
-	ProjectIDs   []int    `json:"projects"`
-	IssueTypeIDs []int    `json:"issues"`
-}
-
-type requestBulkPermissions struct {
-	AccountID          string                     `json:"accountId,omitempty"`
-	GlobalPermissions  []string                   `json:"globalPermissions,omitempty"`
-	ProjectPermissions []requestProjectPermission `json:"projectPermissions,omitempty"`
-}

--- a/project.go
+++ b/project.go
@@ -180,3 +180,25 @@ func (s *ProjectService) GetPermissionSchemeWithContext(ctx context.Context, pro
 func (s *ProjectService) GetPermissionScheme(projectID string) (*PermissionScheme, *Response, error) {
 	return s.GetPermissionSchemeWithContext(context.Background(), projectID)
 }
+
+type BulkProjectPermissions struct {
+	Permission   string `json:"permission"`
+	ProjectIDs   []int  `json:"projects"`
+	IssueTypeIDs []int  `json:"issues"`
+}
+
+type BulkPermissions struct {
+	ProjectPermissions []*BulkProjectPermissions `json:"projectPermissions"`
+	GlobalPermissions  []string                  `json:"globalPermissions"`
+}
+type requestProjectPermission struct {
+	Permissions  []string `json:"permissions"`
+	ProjectIDs   []int    `json:"projects"`
+	IssueTypeIDs []int    `json:"issues"`
+}
+
+type requestBulkPermissions struct {
+	AccountID          string                     `json:"accountId,omitempty"`
+	GlobalPermissions  []string                   `json:"globalPermissions,omitempty"`
+	ProjectPermissions []requestProjectPermission `json:"projectPermissions,omitempty"`
+}


### PR DESCRIPTION
The create-issue-meta API just returns a partial response if you don't
have permission to create issues in that project. It's possible there
are other reasons for that, but we can't really tell without the
GetBulkPermissions API.
