### PR TITLE
Add HierarchyLevel to the IssueType

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -232,15 +232,23 @@ type IssueRenderedFields struct {
 // IssueType represents a type of a Jira issue.
 // Typical types are "Request", "Bug", "Story", ...
 type IssueType struct {
-	Self           string `json:"self,omitempty" structs:"self,omitempty"`
-	ID             string `json:"id,omitempty" structs:"id,omitempty"`
-	Description    string `json:"description,omitempty" structs:"description,omitempty"`
-	IconURL        string `json:"iconUrl,omitempty" structs:"iconUrl,omitempty"`
-	Name           string `json:"name,omitempty" structs:"name,omitempty"`
-	Subtask        bool   `json:"subtask,omitempty" structs:"subtask,omitempty"`
-	AvatarID       int    `json:"avatarId,omitempty" structs:"avatarId,omitempty"`
-	HierarchyLevel *int   `json:"hierarchyLevel,omitempty" structs:"hierarchyLevel,omitempty"`
+	Self           string                   `json:"self,omitempty" structs:"self,omitempty"`
+	ID             string                   `json:"id,omitempty" structs:"id,omitempty"`
+	Description    string                   `json:"description,omitempty" structs:"description,omitempty"`
+	IconURL        string                   `json:"iconUrl,omitempty" structs:"iconUrl,omitempty"`
+	Name           string                   `json:"name,omitempty" structs:"name,omitempty"`
+	Subtask        bool                     `json:"subtask,omitempty" structs:"subtask,omitempty"`
+	AvatarID       int                      `json:"avatarId,omitempty" structs:"avatarId,omitempty"`
+	HierarchyLevel *IssueTypeHierarchyLevel `json:"hierarchyLevel,omitempty" structs:"hierarchyLevel,omitempty"`
 }
+
+type IssueTypeHierarchyLevel = int
+
+const (
+	IssueTypeHierarchyLevelEpic    IssueTypeHierarchyLevel = 1
+	IssueTypeHierarchyLevelTask    IssueTypeHierarchyLevel = 0
+	IssueTypeHierarchyLevelSubTask IssueTypeHierarchyLevel = -1
+)
 
 // Watches represents a type of how many and which user are "observing" a Jira issue to track the status / updates.
 type Watches struct {

--- a/issue.go
+++ b/issue.go
@@ -232,13 +232,14 @@ type IssueRenderedFields struct {
 // IssueType represents a type of a Jira issue.
 // Typical types are "Request", "Bug", "Story", ...
 type IssueType struct {
-	Self        string `json:"self,omitempty" structs:"self,omitempty"`
-	ID          string `json:"id,omitempty" structs:"id,omitempty"`
-	Description string `json:"description,omitempty" structs:"description,omitempty"`
-	IconURL     string `json:"iconUrl,omitempty" structs:"iconUrl,omitempty"`
-	Name        string `json:"name,omitempty" structs:"name,omitempty"`
-	Subtask     bool   `json:"subtask,omitempty" structs:"subtask,omitempty"`
-	AvatarID    int    `json:"avatarId,omitempty" structs:"avatarId,omitempty"`
+	Self           string `json:"self,omitempty" structs:"self,omitempty"`
+	ID             string `json:"id,omitempty" structs:"id,omitempty"`
+	Description    string `json:"description,omitempty" structs:"description,omitempty"`
+	IconURL        string `json:"iconUrl,omitempty" structs:"iconUrl,omitempty"`
+	Name           string `json:"name,omitempty" structs:"name,omitempty"`
+	Subtask        bool   `json:"subtask,omitempty" structs:"subtask,omitempty"`
+	AvatarID       int    `json:"avatarId,omitempty" structs:"avatarId,omitempty"`
+	HierarchyLevel int    `json:"hierarchyLevel,omitempty" structs:"hierarchyLevel,omitempty"`
 }
 
 // Watches represents a type of how many and which user are "observing" a Jira issue to track the status / updates.
@@ -613,7 +614,7 @@ type RemoteLinkStatus struct {
 // This can be an issue id, or an issue key.
 // If the issue cannot be found via an exact match, Jira will also look for the issue in a case-insensitive way, or by looking to see if the issue was moved.
 //
-// The given options will be appended to the query string
+// # The given options will be appended to the query string
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-getIssue
 func (s *IssueService) GetWithContext(ctx context.Context, issueID string, options *GetQueryOptions) (*Issue, *Response, error) {
@@ -1295,15 +1296,17 @@ func (s *IssueService) DoTransitionWithPayload(ticketID, payload interface{}) (*
 }
 
 // InitIssueWithMetaAndFields returns Issue with with values from fieldsConfig properly set.
-//  * metaProject should contain metaInformation about the project where the issue should be created.
-//  * metaIssuetype is the MetaInformation about the Issuetype that needs to be created.
-//  * fieldsConfig is a key->value pair where key represents the name of the field as seen in the UI
-//		And value is the string value for that particular key.
+//   - metaProject should contain metaInformation about the project where the issue should be created.
+//   - metaIssuetype is the MetaInformation about the Issuetype that needs to be created.
+//   - fieldsConfig is a key->value pair where key represents the name of the field as seen in the UI
+//     And value is the string value for that particular key.
+//
 // Note: This method doesn't verify that the fieldsConfig is complete with mandatory fields. The fieldsConfig is
-//		 supposed to be already verified with MetaIssueType.CheckCompleteAndAvailable. It will however return
-//		 error if the key is not found.
-//		 All values will be packed into Unknowns. This is much convenient. If the struct fields needs to be
-//		 configured as well, marshalling and unmarshalling will set the proper fields.
+//
+//	supposed to be already verified with MetaIssueType.CheckCompleteAndAvailable. It will however return
+//	error if the key is not found.
+//	All values will be packed into Unknowns. This is much convenient. If the struct fields needs to be
+//	configured as well, marshalling and unmarshalling will set the proper fields.
 func InitIssueWithMetaAndFields(metaProject *MetaProject, metaIssuetype *MetaIssueType, fieldsConfig map[string]string) (*Issue, error) {
 	issue := new(Issue)
 	issueFields := new(IssueFields)

--- a/issue.go
+++ b/issue.go
@@ -239,7 +239,7 @@ type IssueType struct {
 	Name           string `json:"name,omitempty" structs:"name,omitempty"`
 	Subtask        bool   `json:"subtask,omitempty" structs:"subtask,omitempty"`
 	AvatarID       int    `json:"avatarId,omitempty" structs:"avatarId,omitempty"`
-	HierarchyLevel int    `json:"hierarchyLevel,omitempty" structs:"hierarchyLevel,omitempty"`
+	HierarchyLevel *int   `json:"hierarchyLevel,omitempty" structs:"hierarchyLevel,omitempty"`
 }
 
 // Watches represents a type of how many and which user are "observing" a Jira issue to track the status / updates.


### PR DESCRIPTION
This property should make it easier to work out parent issue hierarchy, used for syncing follow ups to parent epics